### PR TITLE
remove globals key because it is not part of eslint config extension

### DIFF
--- a/reactNative.js
+++ b/reactNative.js
@@ -6,10 +6,6 @@ module.exports = {
   extends: ['airbnb', 'plugin:react-native/all'],
   parser: 'babel-eslint',
   plugins: ['react-hooks'],
-  globals: {
-    __DEV__: true, // this is a special env var provided by RN used to determine dev/prod mode
-    fetch: true, // RN provides the Fetch API
-  },
   rules: {
     ...commonRules,
     ...reactRules,

--- a/reactNativeTypescript.js
+++ b/reactNativeTypescript.js
@@ -9,9 +9,6 @@ module.exports = {
     'airbnb-typescript',
   ],
   plugins: ['react-hooks'],
-  globals: {
-    __DEV__: true,
-  },
   rules: {
     ...commonRules,
     ...reactRules,


### PR DESCRIPTION
ie. when you extend one of the rule sets from this repo, these global settings will not be applied, they need to be added separately in local config (unfortunately).